### PR TITLE
Clean up reservation room claim assignments.

### DIFF
--- a/csharp/HOLMS.Platform/HOLMS.Platform/Support/Time/InclusiveDateRange.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Support/Time/InclusiveDateRange.cs
@@ -32,7 +32,7 @@ namespace HOLMS.Support.Time {
             End = other.End;
         }
 
-        public bool Overlaps(InclusiveDateRange other) => !(other.End < Start && End < other.Start);
+        public bool Overlaps(InclusiveDateRange other) => !(other.End < Start || End < other.Start);
 
         public DateTime StartDateTime {
             get { return new DateTime(Start.Year, Start.Month, Start.Day); }

--- a/csharp/HOLMS.Platform/HOLMS.Platform/Support/Time/InclusiveDateRange.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Support/Time/InclusiveDateRange.cs
@@ -32,6 +32,8 @@ namespace HOLMS.Support.Time {
             End = other.End;
         }
 
+        public bool Overlaps(InclusiveDateRange other) => !(other.End < Start && End < other.Start);
+
         public DateTime StartDateTime {
             get { return new DateTime(Start.Year, Start.Month, Start.Day); }
             set { Start = new LocalDate(value.Year, value.Month, value.Day); }

--- a/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/RoomClaimsSvc.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/RoomClaimsSvc.cs
@@ -58,28 +58,29 @@ namespace HOLMS.Types.Operations.RPC {
             "cy5yb29tX2NsYWltcy5SZXNlcnZhdGlvblJvb21Bc3NpZ25tZW50UmVzdWx0",
             "Il8KHUdldEFsbFJvb21zV2l0aENsYWltc1Jlc3BvbnNlEj4KBXJvb21zGAEg",
             "AygLMi8uaG9sbXMudHlwZXMub3BlcmF0aW9ucy5yb29tcy5Sb29tV2l0aENs",
-            "YWltSW5mbyJRChxHZXRBbGxSb29tc1dpdGhDbGFpbXNSZXF1ZXN0EjEKBWRh",
-            "dGVzGAEgAygLMiIuaG9sbXMudHlwZXMucHJpbWl0aXZlLlBiTG9jYWxEYXRl",
-            "Mp8GCg1Sb29tQ2xhaW1zU3ZjEnkKBlNlYXJjaBI2LmhvbG1zLnR5cGVzLm9w",
-            "ZXJhdGlvbnMucnBjLlJvb21DbGFpbXNTdmNTZWFyY2hSZXF1ZXN0GjcuaG9s",
-            "bXMudHlwZXMub3BlcmF0aW9ucy5ycGMuUm9vbUNsYWltc1N2Y1NlYXJjaFJl",
-            "c3BvbnNlEpMBChZTZWFyY2hDb250aW51b3VzQ2xhaW1zEjYuaG9sbXMudHlw",
-            "ZXMub3BlcmF0aW9ucy5ycGMuUm9vbUNsYWltc1N2Y1NlYXJjaFJlcXVlc3Qa",
-            "QS5ob2xtcy50eXBlcy5vcGVyYXRpb25zLnJwYy5Db250aW51b3VzUm9vbUNs",
-            "YWltc1N2Y1NlYXJjaFJlc3BvbnNlErIBChlHZXRDbGFpbWFibGVCeVJlc2Vy",
-            "dmF0aW9uEkkuaG9sbXMudHlwZXMub3BlcmF0aW9ucy5ycGMuUm9vbUNsYWlt",
-            "c1N2Y0dldENsYWltYWJsZUJ5UmVzZXJ2YXRpb25SZXF1ZXN0GkouaG9sbXMu",
-            "dHlwZXMub3BlcmF0aW9ucy5ycGMuUm9vbUNsYWltc1N2Y0dldENsYWltYWJs",
-            "ZUJ5UmVzZXJ2YXRpb25SZXNwb25zZRK4AQobVXBkYXRlUmVzZXJ2YXRpb25S",
-            "b29tQ2xhaW1zEksuaG9sbXMudHlwZXMub3BlcmF0aW9ucy5ycGMuUm9vbUNs",
-            "YWltc1N2Y1VwZGF0ZVJlc2VydmF0aW9uUm9vbUNsYWltc1JlcXVlc3QaTC5o",
-            "b2xtcy50eXBlcy5vcGVyYXRpb25zLnJwYy5Sb29tQ2xhaW1zU3ZjVXBkYXRl",
-            "UmVzZXJ2YXRpb25Sb29tQ2xhaW1zUmVzcG9uc2USjAEKFUdldEFsbFJvb21z",
-            "V2l0aENsYWltcxI4LmhvbG1zLnR5cGVzLm9wZXJhdGlvbnMucnBjLkdldEFs",
-            "bFJvb21zV2l0aENsYWltc1JlcXVlc3QaOS5ob2xtcy50eXBlcy5vcGVyYXRp",
-            "b25zLnJwYy5HZXRBbGxSb29tc1dpdGhDbGFpbXNSZXNwb25zZUItWg5vcGVy",
-            "YXRpb25zL3JwY6oCGkhPTE1TLlR5cGVzLk9wZXJhdGlvbnMuUlBDYgZwcm90",
-            "bzM="));
+            "YWltSW5mbyKcAQocR2V0QWxsUm9vbXNXaXRoQ2xhaW1zUmVxdWVzdBIxCgVk",
+            "YXRlcxgBIAMoCzIiLmhvbG1zLnR5cGVzLnByaW1pdGl2ZS5QYkxvY2FsRGF0",
+            "ZRJJCgtyZXNlcnZhdGlvbhgCIAEoCzI0LmhvbG1zLnR5cGVzLmJvb2tpbmcu",
+            "aW5kaWNhdG9ycy5SZXNlcnZhdGlvbkluZGljYXRvcjKfBgoNUm9vbUNsYWlt",
+            "c1N2YxJ5CgZTZWFyY2gSNi5ob2xtcy50eXBlcy5vcGVyYXRpb25zLnJwYy5S",
+            "b29tQ2xhaW1zU3ZjU2VhcmNoUmVxdWVzdBo3LmhvbG1zLnR5cGVzLm9wZXJh",
+            "dGlvbnMucnBjLlJvb21DbGFpbXNTdmNTZWFyY2hSZXNwb25zZRKTAQoWU2Vh",
+            "cmNoQ29udGludW91c0NsYWltcxI2LmhvbG1zLnR5cGVzLm9wZXJhdGlvbnMu",
+            "cnBjLlJvb21DbGFpbXNTdmNTZWFyY2hSZXF1ZXN0GkEuaG9sbXMudHlwZXMu",
+            "b3BlcmF0aW9ucy5ycGMuQ29udGludW91c1Jvb21DbGFpbXNTdmNTZWFyY2hS",
+            "ZXNwb25zZRKyAQoZR2V0Q2xhaW1hYmxlQnlSZXNlcnZhdGlvbhJJLmhvbG1z",
+            "LnR5cGVzLm9wZXJhdGlvbnMucnBjLlJvb21DbGFpbXNTdmNHZXRDbGFpbWFi",
+            "bGVCeVJlc2VydmF0aW9uUmVxdWVzdBpKLmhvbG1zLnR5cGVzLm9wZXJhdGlv",
+            "bnMucnBjLlJvb21DbGFpbXNTdmNHZXRDbGFpbWFibGVCeVJlc2VydmF0aW9u",
+            "UmVzcG9uc2USuAEKG1VwZGF0ZVJlc2VydmF0aW9uUm9vbUNsYWltcxJLLmhv",
+            "bG1zLnR5cGVzLm9wZXJhdGlvbnMucnBjLlJvb21DbGFpbXNTdmNVcGRhdGVS",
+            "ZXNlcnZhdGlvblJvb21DbGFpbXNSZXF1ZXN0GkwuaG9sbXMudHlwZXMub3Bl",
+            "cmF0aW9ucy5ycGMuUm9vbUNsYWltc1N2Y1VwZGF0ZVJlc2VydmF0aW9uUm9v",
+            "bUNsYWltc1Jlc3BvbnNlEowBChVHZXRBbGxSb29tc1dpdGhDbGFpbXMSOC5o",
+            "b2xtcy50eXBlcy5vcGVyYXRpb25zLnJwYy5HZXRBbGxSb29tc1dpdGhDbGFp",
+            "bXNSZXF1ZXN0GjkuaG9sbXMudHlwZXMub3BlcmF0aW9ucy5ycGMuR2V0QWxs",
+            "Um9vbXNXaXRoQ2xhaW1zUmVzcG9uc2VCLVoOb3BlcmF0aW9ucy9ycGOqAhpI",
+            "T0xNUy5UeXBlcy5PcGVyYXRpb25zLlJQQ2IGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::HOLMS.Types.Booking.Indicators.ReservationIndicatorReflection.Descriptor, global::HOLMS.Types.Primitive.PbInclusiveOpsdateRangeReflection.Descriptor, global::HOLMS.Types.Primitive.PbLocalDateReflection.Descriptor, global::HOLMS.Types.TenancyConfig.Indicators.PropertyIndicatorReflection.Descriptor, global::HOLMS.Types.Operations.RoomClaims.ReservationRoomAssignmentResultReflection.Descriptor, global::HOLMS.Types.Operations.RoomClaims.RoomAssignmentByNightReflection.Descriptor, global::HOLMS.Types.Operations.RoomClaims.RoomClaimReflection.Descriptor, global::HOLMS.Types.Operations.RoomClaims.ContinuousRoomClaimReflection.Descriptor, global::HOLMS.Types.Operations.Rooms.RoomReflection.Descriptor, global::HOLMS.Types.Operations.Rooms.RoomWithClaimInfoReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
@@ -91,7 +92,7 @@ namespace HOLMS.Types.Operations.RPC {
             new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Operations.RPC.RoomClaimsSvcUpdateReservationRoomClaimsRequest), global::HOLMS.Types.Operations.RPC.RoomClaimsSvcUpdateReservationRoomClaimsRequest.Parser, new[]{ "Reservation", "Requests" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Operations.RPC.RoomClaimsSvcUpdateReservationRoomClaimsResponse), global::HOLMS.Types.Operations.RPC.RoomClaimsSvcUpdateReservationRoomClaimsResponse.Parser, new[]{ "Result" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Operations.RPC.GetAllRoomsWithClaimsResponse), global::HOLMS.Types.Operations.RPC.GetAllRoomsWithClaimsResponse.Parser, new[]{ "Rooms" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Operations.RPC.GetAllRoomsWithClaimsRequest), global::HOLMS.Types.Operations.RPC.GetAllRoomsWithClaimsRequest.Parser, new[]{ "Dates" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Operations.RPC.GetAllRoomsWithClaimsRequest), global::HOLMS.Types.Operations.RPC.GetAllRoomsWithClaimsRequest.Parser, new[]{ "Dates", "Reservation" }, null, null, null)
           }));
     }
     #endregion
@@ -1119,6 +1120,7 @@ namespace HOLMS.Types.Operations.RPC {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public GetAllRoomsWithClaimsRequest(GetAllRoomsWithClaimsRequest other) : this() {
       dates_ = other.dates_.Clone();
+      Reservation = other.reservation_ != null ? other.Reservation.Clone() : null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1136,6 +1138,17 @@ namespace HOLMS.Types.Operations.RPC {
       get { return dates_; }
     }
 
+    /// <summary>Field number for the "reservation" field.</summary>
+    public const int ReservationFieldNumber = 2;
+    private global::HOLMS.Types.Booking.Indicators.ReservationIndicator reservation_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::HOLMS.Types.Booking.Indicators.ReservationIndicator Reservation {
+      get { return reservation_; }
+      set {
+        reservation_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as GetAllRoomsWithClaimsRequest);
@@ -1150,6 +1163,7 @@ namespace HOLMS.Types.Operations.RPC {
         return true;
       }
       if(!dates_.Equals(other.dates_)) return false;
+      if (!object.Equals(Reservation, other.Reservation)) return false;
       return true;
     }
 
@@ -1157,6 +1171,7 @@ namespace HOLMS.Types.Operations.RPC {
     public override int GetHashCode() {
       int hash = 1;
       hash ^= dates_.GetHashCode();
+      if (reservation_ != null) hash ^= Reservation.GetHashCode();
       return hash;
     }
 
@@ -1168,12 +1183,19 @@ namespace HOLMS.Types.Operations.RPC {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
       dates_.WriteTo(output, _repeated_dates_codec);
+      if (reservation_ != null) {
+        output.WriteRawTag(18);
+        output.WriteMessage(Reservation);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int CalculateSize() {
       int size = 0;
       size += dates_.CalculateSize(_repeated_dates_codec);
+      if (reservation_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Reservation);
+      }
       return size;
     }
 
@@ -1183,6 +1205,12 @@ namespace HOLMS.Types.Operations.RPC {
         return;
       }
       dates_.Add(other.dates_);
+      if (other.reservation_ != null) {
+        if (reservation_ == null) {
+          reservation_ = new global::HOLMS.Types.Booking.Indicators.ReservationIndicator();
+        }
+        Reservation.MergeFrom(other.Reservation);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1195,6 +1223,13 @@ namespace HOLMS.Types.Operations.RPC {
             break;
           case 10: {
             dates_.AddEntriesFrom(input, _repeated_dates_codec);
+            break;
+          }
+          case 18: {
+            if (reservation_ == null) {
+              reservation_ = new global::HOLMS.Types.Booking.Indicators.ReservationIndicator();
+            }
+            input.ReadMessage(reservation_);
             break;
           }
         }

--- a/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/RoomWithClaimInfo.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/RoomWithClaimInfo.cs
@@ -23,19 +23,16 @@ namespace HOLMS.Types.Operations.Rooms {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
             "CitvcGVyYXRpb25zL3Jvb21zL3Jvb21fd2l0aF9jbGFpbV9pbmZvLnByb3Rv",
-            "Ehxob2xtcy50eXBlcy5vcGVyYXRpb25zLnJvb21zGi5ib29raW5nL3Jlc2Vy",
-            "dmF0aW9ucy9yZXNlcnZhdGlvbl9zdW1tYXJ5LnByb3RvGhtvcGVyYXRpb25z",
-            "L3Jvb21zL3Jvb20ucHJvdG8izwEKEVJvb21XaXRoQ2xhaW1JbmZvEjAKBHJv",
-            "b20YASABKAsyIi5ob2xtcy50eXBlcy5vcGVyYXRpb25zLnJvb21zLlJvb20S",
-            "HQoVaGFzX3Jlc2VydmF0aW9uX2NsYWltGAIgASgIEhUKDWhhc19vb29fY2xh",
-            "aW0YAyABKAgSUgoUY2xhaW1pbmdfcmVzZXJ2YXRpb24YBCABKAsyNC5ob2xt",
-            "cy50eXBlcy5ib29raW5nLnJlc2VydmF0aW9ucy5SZXNlcnZhdGlvblN1bW1h",
-            "cnlCMVoQb3BlcmF0aW9ucy9yb29tc6oCHEhPTE1TLlR5cGVzLk9wZXJhdGlv",
+            "Ehxob2xtcy50eXBlcy5vcGVyYXRpb25zLnJvb21zGhtvcGVyYXRpb25zL3Jv",
+            "b21zL3Jvb20ucHJvdG8iigEKEVJvb21XaXRoQ2xhaW1JbmZvEjAKBHJvb20Y",
+            "ASABKAsyIi5ob2xtcy50eXBlcy5vcGVyYXRpb25zLnJvb21zLlJvb20SHgoW",
+            "Y3VycmVudGx5X291dF9vZl9vcmRlchgCIAEoCBIjChthc3NpZ25hYmxlX2Zv",
+            "cl90YXJnZXRfZGF0ZXMYAyABKAhCH6oCHEhPTE1TLlR5cGVzLk9wZXJhdGlv",
             "bnMuUm9vbXNiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::HOLMS.Types.Booking.Reservations.ReservationSummaryReflection.Descriptor, global::HOLMS.Types.Operations.Rooms.RoomReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::HOLMS.Types.Operations.Rooms.RoomReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Operations.Rooms.RoomWithClaimInfo), global::HOLMS.Types.Operations.Rooms.RoomWithClaimInfo.Parser, new[]{ "Room", "HasReservationClaim", "HasOooClaim", "ClaimingReservation" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Operations.Rooms.RoomWithClaimInfo), global::HOLMS.Types.Operations.Rooms.RoomWithClaimInfo.Parser, new[]{ "Room", "CurrentlyOutOfOrder", "AssignableForTargetDates" }, null, null, null)
           }));
     }
     #endregion
@@ -67,9 +64,8 @@ namespace HOLMS.Types.Operations.Rooms {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public RoomWithClaimInfo(RoomWithClaimInfo other) : this() {
       Room = other.room_ != null ? other.Room.Clone() : null;
-      hasReservationClaim_ = other.hasReservationClaim_;
-      hasOooClaim_ = other.hasOooClaim_;
-      ClaimingReservation = other.claimingReservation_ != null ? other.ClaimingReservation.Clone() : null;
+      currentlyOutOfOrder_ = other.currentlyOutOfOrder_;
+      assignableForTargetDates_ = other.assignableForTargetDates_;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -88,36 +84,25 @@ namespace HOLMS.Types.Operations.Rooms {
       }
     }
 
-    /// <summary>Field number for the "has_reservation_claim" field.</summary>
-    public const int HasReservationClaimFieldNumber = 2;
-    private bool hasReservationClaim_;
+    /// <summary>Field number for the "currently_out_of_order" field.</summary>
+    public const int CurrentlyOutOfOrderFieldNumber = 2;
+    private bool currentlyOutOfOrder_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasReservationClaim {
-      get { return hasReservationClaim_; }
+    public bool CurrentlyOutOfOrder {
+      get { return currentlyOutOfOrder_; }
       set {
-        hasReservationClaim_ = value;
+        currentlyOutOfOrder_ = value;
       }
     }
 
-    /// <summary>Field number for the "has_ooo_claim" field.</summary>
-    public const int HasOooClaimFieldNumber = 3;
-    private bool hasOooClaim_;
+    /// <summary>Field number for the "assignable_for_target_dates" field.</summary>
+    public const int AssignableForTargetDatesFieldNumber = 3;
+    private bool assignableForTargetDates_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool HasOooClaim {
-      get { return hasOooClaim_; }
+    public bool AssignableForTargetDates {
+      get { return assignableForTargetDates_; }
       set {
-        hasOooClaim_ = value;
-      }
-    }
-
-    /// <summary>Field number for the "claiming_reservation" field.</summary>
-    public const int ClaimingReservationFieldNumber = 4;
-    private global::HOLMS.Types.Booking.Reservations.ReservationSummary claimingReservation_;
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::HOLMS.Types.Booking.Reservations.ReservationSummary ClaimingReservation {
-      get { return claimingReservation_; }
-      set {
-        claimingReservation_ = value;
+        assignableForTargetDates_ = value;
       }
     }
 
@@ -135,9 +120,8 @@ namespace HOLMS.Types.Operations.Rooms {
         return true;
       }
       if (!object.Equals(Room, other.Room)) return false;
-      if (HasReservationClaim != other.HasReservationClaim) return false;
-      if (HasOooClaim != other.HasOooClaim) return false;
-      if (!object.Equals(ClaimingReservation, other.ClaimingReservation)) return false;
+      if (CurrentlyOutOfOrder != other.CurrentlyOutOfOrder) return false;
+      if (AssignableForTargetDates != other.AssignableForTargetDates) return false;
       return true;
     }
 
@@ -145,9 +129,8 @@ namespace HOLMS.Types.Operations.Rooms {
     public override int GetHashCode() {
       int hash = 1;
       if (room_ != null) hash ^= Room.GetHashCode();
-      if (HasReservationClaim != false) hash ^= HasReservationClaim.GetHashCode();
-      if (HasOooClaim != false) hash ^= HasOooClaim.GetHashCode();
-      if (claimingReservation_ != null) hash ^= ClaimingReservation.GetHashCode();
+      if (CurrentlyOutOfOrder != false) hash ^= CurrentlyOutOfOrder.GetHashCode();
+      if (AssignableForTargetDates != false) hash ^= AssignableForTargetDates.GetHashCode();
       return hash;
     }
 
@@ -162,17 +145,13 @@ namespace HOLMS.Types.Operations.Rooms {
         output.WriteRawTag(10);
         output.WriteMessage(Room);
       }
-      if (HasReservationClaim != false) {
+      if (CurrentlyOutOfOrder != false) {
         output.WriteRawTag(16);
-        output.WriteBool(HasReservationClaim);
+        output.WriteBool(CurrentlyOutOfOrder);
       }
-      if (HasOooClaim != false) {
+      if (AssignableForTargetDates != false) {
         output.WriteRawTag(24);
-        output.WriteBool(HasOooClaim);
-      }
-      if (claimingReservation_ != null) {
-        output.WriteRawTag(34);
-        output.WriteMessage(ClaimingReservation);
+        output.WriteBool(AssignableForTargetDates);
       }
     }
 
@@ -182,14 +161,11 @@ namespace HOLMS.Types.Operations.Rooms {
       if (room_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Room);
       }
-      if (HasReservationClaim != false) {
+      if (CurrentlyOutOfOrder != false) {
         size += 1 + 1;
       }
-      if (HasOooClaim != false) {
+      if (AssignableForTargetDates != false) {
         size += 1 + 1;
-      }
-      if (claimingReservation_ != null) {
-        size += 1 + pb::CodedOutputStream.ComputeMessageSize(ClaimingReservation);
       }
       return size;
     }
@@ -205,17 +181,11 @@ namespace HOLMS.Types.Operations.Rooms {
         }
         Room.MergeFrom(other.Room);
       }
-      if (other.HasReservationClaim != false) {
-        HasReservationClaim = other.HasReservationClaim;
+      if (other.CurrentlyOutOfOrder != false) {
+        CurrentlyOutOfOrder = other.CurrentlyOutOfOrder;
       }
-      if (other.HasOooClaim != false) {
-        HasOooClaim = other.HasOooClaim;
-      }
-      if (other.claimingReservation_ != null) {
-        if (claimingReservation_ == null) {
-          claimingReservation_ = new global::HOLMS.Types.Booking.Reservations.ReservationSummary();
-        }
-        ClaimingReservation.MergeFrom(other.ClaimingReservation);
+      if (other.AssignableForTargetDates != false) {
+        AssignableForTargetDates = other.AssignableForTargetDates;
       }
     }
 
@@ -235,18 +205,11 @@ namespace HOLMS.Types.Operations.Rooms {
             break;
           }
           case 16: {
-            HasReservationClaim = input.ReadBool();
+            CurrentlyOutOfOrder = input.ReadBool();
             break;
           }
           case 24: {
-            HasOooClaim = input.ReadBool();
-            break;
-          }
-          case 34: {
-            if (claimingReservation_ == null) {
-              claimingReservation_ = new global::HOLMS.Types.Booking.Reservations.ReservationSummary();
-            }
-            input.ReadMessage(claimingReservation_);
+            AssignableForTargetDates = input.ReadBool();
             break;
           }
         }

--- a/proto/operations/rooms/room_with_claim_info.proto
+++ b/proto/operations/rooms/room_with_claim_info.proto
@@ -2,15 +2,12 @@
 
 package holms.types.operations.rooms;
 option csharp_namespace = "HOLMS.Types.Operations.Rooms";
-option go_package = "operations/rooms";
 
-import "booking/reservations/reservation_summary.proto";
 import "operations/rooms/room.proto";
 
 message RoomWithClaimInfo {
 	.holms.types.operations.rooms.Room room = 1;
-	bool has_reservation_claim = 2;
-	bool has_ooo_claim = 3;
-
-	.holms.types.booking.reservations.ReservationSummary claiming_reservation = 4;
+	bool currently_out_of_order = 2;
+	bool assignable_for_target_dates = 3;
 }
+

--- a/proto/operations/rpc/room_claims_svc.proto
+++ b/proto/operations/rpc/room_claims_svc.proto
@@ -52,6 +52,7 @@ message GetAllRoomsWithClaimsResponse {
 
 message GetAllRoomsWithClaimsRequest {
 	repeated .holms.types.primitive.PbLocalDate dates = 1;
+	.holms.types.booking.indicators.ReservationIndicator reservation = 2;
 }
 
 service RoomClaimsSvc {


### PR DESCRIPTION
Simplifies and reworks how we calculate whether we can assign rooms. It used to be based on occupancy, but what we wanted is assignment. More of the calculation is shifted server-side, making it easier for the client to consume.

[#154909059]